### PR TITLE
Backward Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@
 *.war
 *.ear
 
+# target folder
+target
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/src/main/java/be/cytomine/client/Cytomine.java
+++ b/src/main/java/be/cytomine/client/Cytomine.java
@@ -94,6 +94,18 @@ public class Cytomine {
         this.pass = privateKey;
     }
 
+    /**
+     * Legacy constructor (kept for downward compatibility)
+     * @param host Full url of the Cytomine instance (e.g. 'http://...')
+     * @param publicKey Your cytomine public key
+     * @param privateKey Your cytomine private key
+     * @param basePath the base path (will be ignored)
+     */
+    @Deprecated
+    public Cytomine(String host, String publicKey, String privateKey, String basePath) {
+        this(host,publicKey,privateKey);
+    }
+
     public String getHost() {
         return host;
     }
@@ -116,6 +128,22 @@ public class Cytomine {
     public void setOffset(int offset) {
         this.offset = offset;
     }
+
+    /**
+     * Get the public key of this connection.
+     * @author Philipp Kainz
+     * @since
+     * @return
+     */
+    public String getPublicKey() { return this.publicKey; }
+
+    /**
+     * Get the private key of this connection.
+     * @author Philipp Kainz
+     * @since
+     * @return
+     */
+    public String getPrivateKey() { return this.privateKey; }
 
     /**
      * Go to the next page of a collection


### PR DESCRIPTION
I noticed some changes in the API, hence I suggest these changes to the `Cytomine.java` class:
- adding a legacy constructor, flagged with `@Deprecated`, where the `basePath` is ignored
- adding getter methods for `publicKey` and `privateKey` fields

Cheers,
Phil
